### PR TITLE
Fix backend type references for Prisma and shared package

### DIFF
--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -3,7 +3,6 @@ import { randomBytes } from 'node:crypto';
 import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import type { Prisma, User } from '@prisma/client';
 import type {
   AuthResponse,
   GenericMessageResponse,
@@ -87,6 +86,12 @@ const DEFAULT_REFRESH_TOKEN_EXPIRATION_MS = (() => {
   return parsed;
 })();
 
+type DbUser = Omit<SharedUser, 'createdAt' | 'updatedAt'> & {
+  password: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 interface AuthTokens {
   accessToken: string;
   refreshToken: string;
@@ -163,7 +168,7 @@ export class AuthService {
       orderBy: { createdAt: 'desc' },
     });
 
-    let validToken: Prisma.RefreshTokenWhereUniqueInput | null = null;
+    let validTokenId: string | null = null;
     for (const token of refreshTokens) {
       if (token.expiresAt < new Date()) {
         await this.prisma.refreshToken.delete({ where: { id: token.id } });
@@ -172,16 +177,16 @@ export class AuthService {
 
       const match = await bcrypt.compare(dto.refreshToken, token.tokenHash);
       if (match) {
-        validToken = { id: token.id };
+        validTokenId = token.id;
         break;
       }
     }
 
-    if (!validToken) {
+    if (!validTokenId) {
       throw new UnauthorizedException('Invalid refresh token.');
     }
 
-    await this.prisma.refreshToken.delete({ where: validToken });
+    await this.prisma.refreshToken.delete({ where: { id: validTokenId } });
 
     const tokens = await this.generateTokens(user);
     await this.persistRefreshToken(user.id, tokens.refreshToken);
@@ -266,16 +271,16 @@ export class AuthService {
       orderBy: { createdAt: 'desc' },
     });
 
-    let tokenRecord: { id: string } | null = null;
+    let tokenId: string | null = null;
     for (const token of tokens) {
       const match = await bcrypt.compare(dto.token, token.tokenHash);
       if (match) {
-        tokenRecord = { id: token.id };
+        tokenId = token.id;
         break;
       }
     }
 
-    if (!tokenRecord) {
+    if (!tokenId) {
       throw new BadRequestException('Invalid or expired reset token.');
     }
 
@@ -287,7 +292,7 @@ export class AuthService {
         data: { password: hashedPassword },
       }),
       this.prisma.passwordResetToken.update({
-        where: tokenRecord,
+        where: { id: tokenId },
         data: { consumed: true },
       }),
     ]);
@@ -328,7 +333,7 @@ export class AuthService {
       .replace(/(^-|-$)+/g, '');
   }
 
-  private sanitizeUser(user: User): SharedUser {
+  private sanitizeUser(user: DbUser): SharedUser {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { password, ...sanitized } = user;
 
@@ -339,7 +344,7 @@ export class AuthService {
     };
   }
 
-  private async generateTokens(user: User): Promise<AuthTokens> {
+  private async generateTokens(user: DbUser): Promise<AuthTokens> {
     const payload: TokenPayload = {
       sub: user.id,
       tenantId: user.tenantId,

--- a/packages/backend/src/common/prisma.service.ts
+++ b/packages/backend/src/common/prisma.service.ts
@@ -1,11 +1,8 @@
 import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
-import { Prisma, PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService
-  extends PrismaClient<Prisma.PrismaClientOptions, 'beforeExit'>
-  implements OnModuleInit
-{
+export class PrismaService extends PrismaClient implements OnModuleInit {
   async onModuleInit() {
     await this.$connect();
   }

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -17,6 +17,8 @@
     "esModuleInterop": true,
     "types": ["node"],
     "paths": {
+      "@saas-boilerplate/shared": ["../shared/src/index.ts"],
+      "@saas-boilerplate/shared/*": ["../shared/src/*"],
       "*": ["node_modules/*"]
     }
   }

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -15,7 +15,12 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@saas-boilerplate/shared": ["../shared/src/index.ts"],
+      "@saas-boilerplate/shared/*": ["../shared/src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,9 +1,16 @@
+import { resolve } from 'node:path';
+
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@saas-boilerplate/shared': resolve(__dirname, '../shared/src'),
+    },
+  },
   server: {
     port: 5173,
     open: true


### PR DESCRIPTION
## Summary
- Replaced Prisma type imports with a local `DbUser` alias and updated the refresh/password reset helpers to track token IDs directly, removing reliance on Prisma client exports that no longer exist.
- Simplified `PrismaService` to extend `PrismaClient` without the deprecated generic signature while keeping the shutdown hook logic intact.
- Added TypeScript path mappings so the backend can resolve the shared workspace package during type checking.
- Added a TypeScript base URL and path mappings so the frontend compiler can resolve the shared workspace module without errors.
- Introduced a Vite alias to point `@saas-boilerplate/shared` imports at the shared source during development builds.


## Testing
- `pnpm exec tsc --project packages/backend/tsconfig.json --noEmit`
- `pnpm exec tsc --project packages/frontend/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68d09842ad8c832c945987f3a000e726