### PR TITLE
Fix GHCR tag case in Docker build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
             exit 0
           fi
 
+          image_prefix=$(echo "$IMAGE_PREFIX" | tr '[:upper:]' '[:lower:]')
+
           for dockerfile in "${dockerfiles[@]}"; do
             context_dir=$(dirname "$dockerfile")
             relative_path=${dockerfile#./}
@@ -114,7 +116,7 @@ jobs:
             if [ -z "$sanitized_tag" ]; then
               sanitized_tag=image
             fi
-            tag="$IMAGE_PREFIX:${sanitized_tag}-ci"
+            tag="$image_prefix:${sanitized_tag}-ci"
             echo "::group::Building ${dockerfile}"
             docker build --file "$dockerfile" "$context_dir" --tag "$tag"
             echo "Tagged image as $tag"


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions Docker build step lowercases the GHCR image prefix before tagging images

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d09d0621bc832ca151530583b2bbb5