### PR TITLE
fix: ensure shared package installs typescript

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,12 +13,14 @@
     "lint": "eslint --ext .ts src",
     "format": "prettier --write \"src/**/*.ts\""
   },
+  "dependencies": {
+    "typescript": "^5.3.3"
+  },
   "devDependencies": {
     "@types/node": "^20.10.5",
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "prettier": "^3.0.3",
-    "typescript": "^5.3.3"
+    "prettier": "^3.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,10 @@ importers:
         version: 5.9.2
 
   packages/shared:
+    dependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.2
     devDependencies:
       '@types/node':
         specifier: ^20.10.5
@@ -227,9 +231,6 @@ importers:
       prettier:
         specifier: ^3.0.3
         version: 3.6.2
-      typescript:
-        specifier: ^5.3.3
-        version: 5.9.2
 
 packages:
 
@@ -5484,7 +5485,7 @@ packages:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
+    dev: false
 
   /uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}


### PR DESCRIPTION
## Summary
- move the shared workspace TypeScript dependency from devDependencies to dependencies so the build has access to `tsc`
- update the pnpm lockfile to record the new dependency scope so filtered installs include TypeScript

## Testing
- pnpm install --frozen-lockfile --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... *(fails: registry fetch blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b27b9e38832c8513843e61e1d0df