### PR TITLE
Fix shared package build to locate TypeScript compiler

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "node ./scripts/build.cjs",
     "lint": "eslint --ext .ts src",
     "format": "prettier --write \"src/**/*.ts\""
   },

--- a/packages/shared/scripts/build.cjs
+++ b/packages/shared/scripts/build.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const { resolve } = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function exitWithError(message, error) {
+  console.error(message);
+  if (error) {
+    console.error(error);
+  }
+  process.exit(1);
+}
+
+let tscExecutable;
+try {
+  tscExecutable = require.resolve('typescript/bin/tsc', { paths: [__dirname] });
+} catch (error) {
+  exitWithError('Unable to locate the local TypeScript compiler. Did you install dependencies for @saas-boilerplate/shared?', error);
+}
+
+const tsconfigPath = resolve(__dirname, '../tsconfig.build.json');
+
+const result = spawnSync(process.execPath, [tscExecutable, '--project', tsconfigPath], {
+  stdio: 'inherit',
+});
+
+if (typeof result.status === 'number' && result.status !== 0) {
+  process.exit(result.status);
+}
+
+if (result.error) {
+  exitWithError('Failed to run the TypeScript compiler.', result.error);
+}


### PR DESCRIPTION
## Summary
- update the @saas-boilerplate/shared build script to invoke a local helper instead of relying on a globally available `tsc`
- add a Node-based build helper that resolves the TypeScript CLI from the package dependencies and provides clearer error output when it is missing

## Testing
- ⚠️ `pnpm --filter @saas-boilerplate/shared run build` *(fails in this environment because corepack cannot download pnpm@8.15.4 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b4e4deac832cbd579e4be5925d8a