### PR TITLE
Improve TypeScript resolution for shared package build

### DIFF
--- a/packages/shared/scripts/build.cjs
+++ b/packages/shared/scripts/build.cjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-const { resolve } = require('node:path');
+const { existsSync, readdirSync } = require('node:fs');
+const { resolve, dirname } = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 function exitWithError(message, error) {
@@ -10,11 +11,65 @@ function exitWithError(message, error) {
   process.exit(1);
 }
 
+const packageRoot = resolve(__dirname, '..');
+
+const candidateResolutionDirectories = new Set([
+  __dirname,
+  packageRoot,
+]);
+
+const workspaceRoot = (() => {
+  let current = packageRoot;
+
+  while (true) {
+    const parent = resolve(current, '..');
+
+    if (parent === current) {
+      return null;
+    }
+
+    if (existsSync(resolve(parent, 'pnpm-workspace.yaml'))) {
+      return parent;
+    }
+
+    current = parent;
+  }
+})();
+
+if (workspaceRoot) {
+  candidateResolutionDirectories.add(workspaceRoot);
+
+  const packagesDir = resolve(workspaceRoot, 'packages');
+  try {
+    for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        candidateResolutionDirectories.add(resolve(packagesDir, entry.name));
+      }
+    }
+  } catch (error) {
+    if (error && error.code !== 'ENOENT') {
+      console.warn('Failed to inspect workspace packages while resolving TypeScript.', error);
+    }
+  }
+}
+
 let tscExecutable;
-try {
-  tscExecutable = require.resolve('typescript/bin/tsc', { paths: [__dirname] });
-} catch (error) {
-  exitWithError('Unable to locate the local TypeScript compiler. Did you install dependencies for @saas-boilerplate/shared?', error);
+for (const baseDir of candidateResolutionDirectories) {
+  try {
+    const typescriptPackageJson = require.resolve('typescript/package.json', { paths: [baseDir] });
+    tscExecutable = resolve(dirname(typescriptPackageJson), 'bin', 'tsc');
+    break;
+  } catch (error) {
+    if (error && error.code !== 'MODULE_NOT_FOUND') {
+      console.warn(`Attempted to resolve TypeScript from "${baseDir}" but failed.`, error);
+    }
+  }
+}
+
+if (!tscExecutable) {
+  exitWithError(
+    'Unable to locate the local TypeScript compiler. Did you install dependencies for @saas-boilerplate/shared?',
+  );
 }
 
 const tsconfigPath = resolve(__dirname, '../tsconfig.build.json');


### PR DESCRIPTION
## Summary
- extend the shared build script to resolve the TypeScript compiler from the workspace root and sibling packages
- keep the existing failure messaging while logging non-resolution errors for easier debugging

## Testing
- pnpm --filter @saas-boilerplate/shared run build *(fails: unable to download pnpm inside the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ba09d9bc832ca0b97f5bef84ca8c