### PR TITLE
Ensure frontend docker setup installs workspace package dev deps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       - frontend-node-modules:/workspace/packages/shared/node_modules
       - frontend-pnpm-store:/root/.local/share/pnpm/store
     command: >
-      sh -c "pnpm install --frozen-lockfile --filter frontend... --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... &&
+      sh -c "pnpm install --frozen-lockfile --filter frontend --filter frontend... --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... &&
              pnpm --filter @saas-boilerplate/shared run build &&
              pnpm --filter frontend dev -- --host 0.0.0.0 --port 5173"
     healthcheck:

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -21,6 +21,7 @@ COPY packages/shared/package.json packages/shared/package.json
 
 # Pre-install frontend dependencies for faster container start-up.
 RUN pnpm install --frozen-lockfile \
+    --filter frontend \
     --filter frontend... \
     --filter @saas-boilerplate/shared \
     --filter @saas-boilerplate/shared...


### PR DESCRIPTION
## Summary
- ensure the frontend container install command includes the frontend workspace itself so dev-only dependencies like Vite are linked
- mirror the same filter update in the frontend Dockerfile layer used for dependency preinstallation

## Testing
- not run (pnpm cannot be bootstrapped in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d0beb20f94832ca963d385d1d98d60