### PR TITLE
Fix frontend docker dev server restart loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - backend-node-modules:/workspace/packages/shared/node_modules
       - backend-pnpm-store:/root/.local/share/pnpm/store
     command: >
-      sh -c "pnpm install --frozen-lockfile --filter backend... --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... &&
+      sh -c "pnpm install --frozen-lockfile --prod=false --filter backend... --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... &&
              pnpm --filter @saas-boilerplate/shared run build &&
              pnpm --filter backend prisma:generate &&
              pnpm --filter backend start:dev"
@@ -96,7 +96,7 @@ services:
       - frontend-node-modules:/workspace/packages/shared/node_modules
       - frontend-pnpm-store:/root/.local/share/pnpm/store
     command: >
-      sh -c "pnpm install --frozen-lockfile --filter frontend --filter frontend... --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... &&
+      sh -c "pnpm install --frozen-lockfile --prod=false --filter frontend --filter frontend... --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... &&
              pnpm --filter @saas-boilerplate/shared run build &&
              pnpm --filter frontend dev -- --host 0.0.0.0 --port 5173"
     healthcheck:

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -20,7 +20,7 @@ COPY packages/backend/package.json packages/backend/package.json
 COPY packages/shared/package.json packages/shared/package.json
 
 # Install the backend and shared dependencies for faster subsequent starts.
-RUN pnpm install --frozen-lockfile \
+RUN pnpm install --frozen-lockfile --prod=false \
     --filter backend... \
     --filter @saas-boilerplate/shared \
     --filter @saas-boilerplate/shared...

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -20,7 +20,7 @@ COPY packages/frontend/package.json packages/frontend/package.json
 COPY packages/shared/package.json packages/shared/package.json
 
 # Pre-install frontend dependencies for faster container start-up.
-RUN pnpm install --frozen-lockfile \
+RUN pnpm install --frozen-lockfile --prod=false \
     --filter frontend \
     --filter frontend... \
     --filter @saas-boilerplate/shared \


### PR DESCRIPTION
## Summary
- force pnpm to install development dependencies in the backend and frontend Docker images
- ensure the docker-compose bootstrap commands also install dev dependencies before starting the app

## Testing
- not run (pnpm installation requires external registry access in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0c2caf530832ca6f210827305e4ee