### PR TITLE
Fix CORS handling for login requests

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,5 +1,6 @@
 # Server configuration
 PORT=3000
+# Comma-separated list of allowed origins ("*" reflects the request origin)
 CORS_ORIGIN=http://localhost:5173
 
 # Database connection

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -8,8 +8,33 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
 
+  const configuredOrigins = configService.get<string>('CORS_ORIGIN', '*');
+  const normalizeOrigin = (origin: string) => origin.replace(/\/$/, '');
+  const allowedOrigins = configuredOrigins
+    .split(',')
+    .map((origin) => normalizeOrigin(origin.trim()))
+    .filter(Boolean);
+
   app.enableCors({
-    origin: configService.get<string>('CORS_ORIGIN', '*'),
+    origin: (origin, callback) => {
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+
+      const normalizedOrigin = normalizeOrigin(origin);
+      const isAllowed =
+        allowedOrigins.length === 0 ||
+        allowedOrigins.includes('*') ||
+        allowedOrigins.includes(normalizedOrigin);
+
+      if (isAllowed) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error(`Origin ${origin} not allowed by CORS`));
+    },
     credentials: true,
   });
 


### PR DESCRIPTION
## Summary
- parse the configured CORS origins and allow multiple values while supporting wildcards with credentials
- normalize origins before comparison so trailing slashes or missing configuration stop breaking login preflights
- document how to configure multiple allowed origins in the backend environment example

## Testing
- pnpm --filter backend lint *(fails: unable to download pnpm because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cf405800832ca82b16d30fc970fe