### PR TITLE
Extend Prisma schema for tenant memberships and billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Generate the Prisma client, run migrations (creates the schema based on `prisma/
 
 ```bash
 pnpm prisma:generate
-pnpm --filter backend prisma:migrate
+pnpm --filter backend prisma:deploy
 pnpm prisma:seed
 ```
 
 - Customize the seed user or tenant by overriding the `SEED_*` variables in `packages/backend/.env` before running the seed command.
+- To iteratively evolve the schema during development you can still run `pnpm --filter backend prisma:migrate`, but the Docker startup sequence now uses the non-interactive `prisma migrate deploy` flow so containers do not pause waiting for confirmation prompts.
 
 ### 5. Run the apps
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ pnpm prisma:seed
 - Customize the seed user or tenant by overriding the `SEED_*` variables in `packages/backend/.env` before running the seed command.
 - To iteratively evolve the schema during development you can still run `pnpm --filter backend prisma:migrate`, but the Docker startup sequence now uses the non-interactive `prisma migrate deploy` flow so containers do not pause waiting for confirmation prompts.
 
+> **Troubleshooting tip:** If the dashboard still shows “No tenant assigned” after seeding, confirm that the API and the seed command are pointed at the same `DATABASE_URL`. The seed output is written to whichever database the command connects to, so mismatched URLs (for example `localhost` on the host machine versus `postgres` inside Docker) will lead to empty memberships in API responses.
+
 ### 5. Run the apps
 
 Start the backend API and the frontend SPA concurrently:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       sh -c "pnpm install --frozen-lockfile --prod=false --filter backend... --filter @saas-boilerplate/shared --filter @saas-boilerplate/shared... &&
              pnpm --filter @saas-boilerplate/shared run build &&
              pnpm --filter backend prisma:generate &&
-             pnpm --filter backend prisma:migrate &&
+             pnpm --filter backend prisma:deploy &&
              pnpm --filter backend prisma:seed &&
              pnpm --filter backend start:dev"
     healthcheck:

--- a/packages/backend/prisma/migrations/20251115090000_extend_schema/migration.sql
+++ b/packages/backend/prisma/migrations/20251115090000_extend_schema/migration.sql
@@ -1,0 +1,159 @@
+-- Create new enums for roles, permissions, and subscriptions
+CREATE TYPE "Permission" AS ENUM ('MANAGE_USERS', 'MANAGE_BILLING', 'VIEW_BILLING', 'MANAGE_SUBSCRIPTION');
+CREATE TYPE "SubscriptionStatus" AS ENUM (
+    'INCOMPLETE',
+    'INCOMPLETE_EXPIRED',
+    'TRIALING',
+    'ACTIVE',
+    'PAST_DUE',
+    'CANCELED',
+    'UNPAID',
+    'PAUSED'
+);
+CREATE TYPE "RoleName" AS ENUM ('OWNER', 'ADMIN', 'MEMBER');
+
+-- Extend existing tables with new metadata
+ALTER TABLE "User"
+    ADD COLUMN "isEmailVerified" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "Tenant"
+    ADD COLUMN "domain" TEXT;
+
+-- Create role and membership tables for multi-tenant access control
+CREATE TABLE "Role" (
+    "id" TEXT NOT NULL,
+    "name" "RoleName" NOT NULL,
+    "description" TEXT,
+    "permissions" "Permission"[] NOT NULL DEFAULT ARRAY[]::"Permission"[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Role_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Role_name_key" ON "Role"("name");
+
+CREATE TABLE "Membership" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "roleId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Membership_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Membership_userId_tenantId_key" ON "Membership"("userId", "tenantId");
+CREATE INDEX "Membership_tenantId_idx" ON "Membership"("tenantId");
+CREATE INDEX "Membership_roleId_idx" ON "Membership"("roleId");
+
+-- Billing resources
+CREATE TABLE "Subscription" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "stripeSubscriptionId" TEXT NOT NULL,
+    "status" "SubscriptionStatus" NOT NULL,
+    "currentPeriodEnd" TIMESTAMP(3) NOT NULL,
+    "cancelAtPeriodEnd" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Subscription_stripeSubscriptionId_key" ON "Subscription"("stripeSubscriptionId");
+CREATE INDEX "Subscription_tenantId_idx" ON "Subscription"("tenantId");
+
+CREATE TABLE "PaymentMethod" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "stripePaymentMethodId" TEXT NOT NULL,
+    "brand" TEXT,
+    "last4" TEXT,
+    "expMonth" INTEGER,
+    "expYear" INTEGER,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PaymentMethod_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PaymentMethod_stripePaymentMethodId_key" ON "PaymentMethod"("stripePaymentMethodId");
+CREATE INDEX "PaymentMethod_tenantId_idx" ON "PaymentMethod"("tenantId");
+
+CREATE TABLE "Invoice" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "stripeInvoiceId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "amountDue" INTEGER NOT NULL,
+    "amountPaid" INTEGER NOT NULL DEFAULT 0,
+    "currency" TEXT NOT NULL DEFAULT 'usd',
+    "issuedAt" TIMESTAMP(3) NOT NULL,
+    "dueAt" TIMESTAMP(3),
+    "paidAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Invoice_stripeInvoiceId_key" ON "Invoice"("stripeInvoiceId");
+CREATE INDEX "Invoice_tenantId_idx" ON "Invoice"("tenantId");
+CREATE INDEX "Invoice_issuedAt_idx" ON "Invoice"("issuedAt");
+
+-- Strengthen token storage with revocation tracking
+ALTER TABLE "RefreshToken"
+    ADD COLUMN "revoked" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX "RefreshToken_expiresAt_idx" ON "RefreshToken"("expiresAt");
+
+CREATE INDEX "PasswordResetToken_expiresAt_idx" ON "PasswordResetToken"("expiresAt");
+
+-- Maintain referential integrity for dependent tables
+ALTER TABLE "RefreshToken" DROP CONSTRAINT "RefreshToken_userId_fkey";
+ALTER TABLE "RefreshToken"
+    ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PasswordResetToken" DROP CONSTRAINT "PasswordResetToken_userId_fkey";
+ALTER TABLE "PasswordResetToken"
+    ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Membership"
+    ADD CONSTRAINT "Membership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Membership"
+    ADD CONSTRAINT "Membership_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Membership"
+    ADD CONSTRAINT "Membership_roleId_fkey" FOREIGN KEY ("roleId") REFERENCES "Role"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Subscription"
+    ADD CONSTRAINT "Subscription_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PaymentMethod"
+    ADD CONSTRAINT "PaymentMethod_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Invoice"
+    ADD CONSTRAINT "Invoice_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "Tenant_domain_key" ON "Tenant"("domain");
+
+-- Seed default roles with example permissions
+INSERT INTO "Role" ("id", "name", "description", "permissions")
+VALUES
+    ('role-owner', 'OWNER', 'Tenant owner with unrestricted access', ARRAY['MANAGE_USERS', 'MANAGE_BILLING', 'VIEW_BILLING', 'MANAGE_SUBSCRIPTION']::"Permission"[]),
+    ('role-admin', 'ADMIN', 'Tenant admin with management capabilities', ARRAY['MANAGE_USERS', 'MANAGE_BILLING', 'VIEW_BILLING', 'MANAGE_SUBSCRIPTION']::"Permission"[]),
+    ('role-member', 'MEMBER', 'Standard tenant member with read access', ARRAY['VIEW_BILLING']::"Permission"[])
+ON CONFLICT ("name") DO NOTHING;
+
+-- Migrate existing single-tenant assignments into memberships
+INSERT INTO "Membership" ("id", "userId", "tenantId", "roleId")
+SELECT
+    md5(random()::text),
+    "id" AS "userId",
+    "tenantId",
+    CASE
+        WHEN "role" = 'OWNER' THEN 'role-owner'
+        WHEN "role" = 'ADMIN' THEN 'role-admin'
+        ELSE 'role-member'
+    END AS "roleId"
+FROM "User";
+
+-- Drop legacy tenant and role columns now represented by memberships
+ALTER TABLE "User" DROP CONSTRAINT "User_tenantId_fkey";
+ALTER TABLE "User" DROP COLUMN "tenantId";
+ALTER TABLE "User" DROP COLUMN "role";
+

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -7,48 +7,179 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Tenant {
-  id        String   @id @default(cuid())
-  name      String
-  slug      String   @unique
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  users     User[]
+/// Granular permissions available to roles.
+enum Permission {
+  MANAGE_USERS
+  MANAGE_BILLING
+  VIEW_BILLING
+  MANAGE_SUBSCRIPTION
+}
+
+/// Subscription lifecycle statuses mirrored from Stripe.
+enum SubscriptionStatus {
+  INCOMPLETE
+  INCOMPLETE_EXPIRED
+  TRIALING
+  ACTIVE
+  PAST_DUE
+  CANCELED
+  UNPAID
+  PAUSED
+}
+
+/// Supported role identifiers.
+enum RoleName {
+  OWNER
+  ADMIN
+  MEMBER
 }
 
 model User {
-  id                   String                @id @default(cuid())
-  email                String                @unique
-  password             String
-  name                 String?
-  role                 String                @default("USER")
-  tenantId             String
-  tenant               Tenant                @relation(fields: [tenantId], references: [id])
-  refreshTokens        RefreshToken[]
-  passwordResetTokens  PasswordResetToken[]
-  createdAt            DateTime              @default(now())
-  updatedAt            DateTime              @updatedAt
+  /// Application user account with profile and auth metadata.
+  /// Example: { "email": "jane@example.com", "name": "Jane Doe" }
+  id                  String                @id @default(cuid())
+  email               String
+  name                String?
+  password            String
+  isEmailVerified     Boolean               @default(false)
+  createdAt           DateTime              @default(now())
+  updatedAt           DateTime              @updatedAt
+  memberships         Membership[]
+  refreshTokens       RefreshToken[]
+  passwordResetTokens PasswordResetToken[]
+
+  @@unique([email])
+}
+
+model Tenant {
+  /// Company or workspace that groups users and billing resources.
+  /// Example: { "name": "Acme Inc", "slug": "acme" }
+  id              String           @id @default(cuid())
+  name            String
+  slug            String           @unique
+  domain          String?          @unique
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  memberships     Membership[]
+  subscriptions   Subscription[]
+  paymentMethods  PaymentMethod[]
+  invoices        Invoice[]
+}
+
+model Membership {
+  /// Links a user to a tenant with a specific role assignment.
+  /// Example: { "userId": "user_cuid", "tenantId": "tenant_cuid", "roleId": "role-owner" }
+  id        String   @id @default(cuid())
+  userId    String
+  tenantId  String
+  roleId    String
+  createdAt DateTime @default(now())
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  role   Role   @relation(fields: [roleId], references: [id], onDelete: Restrict)
+
+  @@unique([userId, tenantId])
+  @@index([tenantId])
+  @@index([roleId])
+}
+
+model Role {
+  /// Defines reusable permission bundles assignable to memberships.
+  /// Example: { "name": OWNER, "permissions": [MANAGE_USERS, MANAGE_BILLING] }
+  id          String       @id @default(cuid())
+  name        RoleName     @unique
+  description String?
+  permissions Permission[] @default([])
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  memberships Membership[]
 }
 
 model RefreshToken {
-  id         String   @id @default(cuid())
-  tokenHash  String
-  userId     String
-  user       User     @relation(fields: [userId], references: [id])
-  expiresAt  DateTime
-  createdAt  DateTime @default(now())
-
-  @@index([userId])
-}
-
-model PasswordResetToken {
+  /// Stores hashed refresh tokens for session continuation.
+  /// Example: { "tokenHash": "<hash>", "userId": "user_cuid" }
   id        String   @id @default(cuid())
   tokenHash String
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  expiresAt DateTime
+  revoked   Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+}
+
+model PasswordResetToken {
+  /// One-time password reset tokens hashed for security.
+  /// Example: { "userId": "user_cuid", "expiresAt": "2024-01-01T00:00:00Z" }
+  id        String   @id @default(cuid())
+  tokenHash String
+  userId    String
   expiresAt DateTime
   consumed  Boolean  @default(false)
   createdAt DateTime @default(now())
 
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
   @@index([userId])
+  @@index([expiresAt])
+}
+
+model Subscription {
+  /// Tracks an active SaaS billing subscription for a tenant.
+  /// Example: { "stripeSubscriptionId": "sub_123", "status": ACTIVE }
+  id                   String              @id @default(cuid())
+  tenantId             String
+  stripeSubscriptionId String              @unique
+  status               SubscriptionStatus
+  currentPeriodEnd     DateTime
+  cancelAtPeriodEnd    Boolean             @default(false)
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+}
+
+model PaymentMethod {
+  /// Stored billing payment methods synced from Stripe.
+  /// Example: { "stripePaymentMethodId": "pm_123", "brand": "visa" }
+  id                    String   @id @default(cuid())
+  tenantId              String
+  stripePaymentMethodId String   @unique
+  brand                 String?
+  last4                 String?
+  expMonth              Int?
+  expYear               Int?
+  isDefault             Boolean  @default(false)
+  createdAt             DateTime @default(now())
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+}
+
+model Invoice {
+  /// Billing invoices issued to a tenant.
+  /// Example: { "stripeInvoiceId": "in_123", "amountDue": 5000 }
+  id              String   @id @default(cuid())
+  tenantId        String
+  stripeInvoiceId String   @unique
+  status          String
+  amountDue       Int
+  amountPaid      Int       @default(0)
+  currency        String    @default("usd")
+  issuedAt        DateTime
+  dueAt           DateTime?
+  paidAt          DateTime?
+  createdAt       DateTime  @default(now())
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@index([issuedAt])
 }

--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -1,7 +1,23 @@
 import { PrismaClient } from '@prisma/client';
+import type { Permission, RoleName } from '@saas-boilerplate/shared';
 import * as bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
+
+const ROLE_DEFINITIONS: Record<RoleName, { description: string; permissions: Permission[] }> = {
+  OWNER: {
+    description: 'Tenant owner with unrestricted access to manage billing and users.',
+    permissions: ['MANAGE_USERS', 'MANAGE_BILLING', 'VIEW_BILLING', 'MANAGE_SUBSCRIPTION'],
+  },
+  ADMIN: {
+    description: 'Administrator who can manage users and billing settings.',
+    permissions: ['MANAGE_USERS', 'MANAGE_BILLING', 'VIEW_BILLING', 'MANAGE_SUBSCRIPTION'],
+  },
+  MEMBER: {
+    description: 'Standard member with read-only access to billing information.',
+    permissions: ['VIEW_BILLING'],
+  },
+};
 
 function slugify(value: string) {
   return value
@@ -11,42 +27,92 @@ function slugify(value: string) {
     .replace(/(^-|-$)+/g, '');
 }
 
+function extractDomain(email: string | undefined): string | null {
+  if (!email) {
+    return null;
+  }
+
+  const [, domain] = email.split('@');
+  return domain ? domain.toLowerCase() : null;
+}
+
+async function ensureDefaultRoles() {
+  await Promise.all(
+    (Object.entries(ROLE_DEFINITIONS) as Array<[RoleName, { description: string; permissions: Permission[] }]>)
+      .map(([name, definition]) =>
+        prisma.role.upsert({
+          where: { name },
+          update: {
+            description: definition.description,
+            permissions: definition.permissions,
+          },
+          create: {
+            id: `role-${name.toLowerCase()}`,
+            name,
+            description: definition.description,
+            permissions: definition.permissions,
+          },
+        }),
+      ),
+  );
+}
+
 async function seed() {
   const tenantName = process.env.SEED_TENANT_NAME ?? 'Acme Inc';
   const tenantSlug = (process.env.SEED_TENANT_SLUG ?? slugify(tenantName))?.trim() || 'seed-tenant';
   const adminName = process.env.SEED_ADMIN_NAME ?? 'Acme Admin';
   const adminEmail = process.env.SEED_ADMIN_EMAIL ?? 'admin@acme.inc';
   const adminPassword = process.env.SEED_ADMIN_PASSWORD ?? 'ChangeMe123!';
-  const adminRole = process.env.SEED_ADMIN_ROLE ?? 'ADMIN';
+
+  await ensureDefaultRoles();
 
   const hashedPassword = await bcrypt.hash(adminPassword, 10);
 
   const tenant = await prisma.tenant.upsert({
     where: { slug: tenantSlug },
     update: {
-      name: tenantName
+      name: tenantName,
+      domain: extractDomain(adminEmail),
     },
     create: {
       name: tenantName,
-      slug: tenantSlug
-    }
+      slug: tenantSlug,
+      domain: extractDomain(adminEmail),
+    },
   });
 
   const user = await prisma.user.upsert({
     where: { email: adminEmail },
     update: {
       name: adminName,
-      role: adminRole,
       password: hashedPassword,
-      tenantId: tenant.id
+      isEmailVerified: true,
     },
     create: {
       name: adminName,
       email: adminEmail,
-      role: adminRole,
       password: hashedPassword,
-      tenantId: tenant.id
-    }
+      isEmailVerified: true,
+    },
+  });
+
+  const ownerRole = await prisma.role.findUniqueOrThrow({ where: { name: 'OWNER' } });
+
+  await prisma.membership.upsert({
+    where: {
+      userId_tenantId: {
+        userId: user.id,
+        tenantId: tenant.id,
+      },
+    },
+    update: {
+      roleId: ownerRole.id,
+    },
+    create: {
+      userId: user.id,
+      tenantId: tenant.id,
+      roleId: ownerRole.id,
+    },
   });
 
   console.log('Seed complete');

--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, SubscriptionStatus } from '@prisma/client';
 import type { Permission, RoleName } from '@saas-boilerplate/shared';
 import * as bcrypt from 'bcryptjs';
 
@@ -36,6 +36,22 @@ function extractDomain(email: string | undefined): string | null {
   return domain ? domain.toLowerCase() : null;
 }
 
+function addDays(base: Date, days: number) {
+  const result = new Date(base);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+function startOfMonth(base: Date) {
+  return new Date(base.getFullYear(), base.getMonth(), 1);
+}
+
+function monthsAgo(base: Date, months: number) {
+  const result = new Date(base);
+  result.setMonth(result.getMonth() - months);
+  return result;
+}
+
 async function ensureDefaultRoles() {
   await Promise.all(
     (Object.entries(ROLE_DEFINITIONS) as Array<[RoleName, { description: string; permissions: Permission[] }]>)
@@ -57,6 +73,62 @@ async function ensureDefaultRoles() {
   );
 }
 
+async function upsertUserWithMembership({
+  email,
+  name,
+  passwordHash,
+  tenantId,
+  roleName,
+  isEmailVerified = true,
+}: {
+  email: string;
+  name: string;
+  passwordHash: string;
+  tenantId: string;
+  roleName: RoleName;
+  isEmailVerified?: boolean;
+}) {
+  const user = await prisma.user.upsert({
+    where: { email },
+    update: {
+      name,
+      password: passwordHash,
+      isEmailVerified,
+    },
+    create: {
+      name,
+      email,
+      password: passwordHash,
+      isEmailVerified,
+    },
+  });
+
+  const role = await prisma.role.findUnique({ where: { name: roleName } });
+
+  if (!role) {
+    throw new Error(`Required role ${roleName} was not found while seeding users.`);
+  }
+
+  const membership = await prisma.membership.upsert({
+    where: {
+      userId_tenantId: {
+        userId: user.id,
+        tenantId,
+      },
+    },
+    update: {
+      roleId: role.id,
+    },
+    create: {
+      userId: user.id,
+      tenantId,
+      roleId: role.id,
+    },
+  });
+
+  return { user, membership, role };
+}
+
 async function seed() {
   const tenantName = process.env.SEED_TENANT_NAME ?? 'Acme Inc';
   const tenantSlug = (process.env.SEED_TENANT_SLUG ?? slugify(tenantName))?.trim() || 'seed-tenant';
@@ -67,63 +139,155 @@ async function seed() {
   await ensureDefaultRoles();
 
   const hashedPassword = await bcrypt.hash(adminPassword, 10);
+  const tenantDomain = extractDomain(adminEmail);
+  const tenantIdentifier = tenantSlug.replace(/[^a-z0-9]/g, '') || 'seed';
 
   const tenant = await prisma.tenant.upsert({
     where: { slug: tenantSlug },
     update: {
       name: tenantName,
-      domain: extractDomain(adminEmail),
+      domain: tenantDomain,
     },
     create: {
       name: tenantName,
       slug: tenantSlug,
-      domain: extractDomain(adminEmail),
+      domain: tenantDomain,
     },
   });
 
-  const user = await prisma.user.upsert({
-    where: { email: adminEmail },
-    update: {
-      name: adminName,
-      password: hashedPassword,
-      isEmailVerified: true,
-    },
-    create: {
-      name: adminName,
-      email: adminEmail,
-      password: hashedPassword,
-      isEmailVerified: true,
-    },
+  const { user: adminUser } = await upsertUserWithMembership({
+    email: adminEmail,
+    name: adminName,
+    passwordHash: hashedPassword,
+    tenantId: tenant.id,
+    roleName: 'OWNER',
   });
 
-  const ownerRole = await prisma.role.findUnique({ where: { name: 'OWNER' } });
+  const sampleTeamMembers: Array<{ name: string; email: string; roleName: RoleName }> = [
+    {
+      name: 'Billie Billing',
+      email: `billing@${tenantDomain ?? `${tenantIdentifier}.example.com`}`,
+      roleName: 'ADMIN',
+    },
+    {
+      name: 'Casey Collaborator',
+      email: `team@${tenantDomain ?? `${tenantIdentifier}.example.com`}`,
+      roleName: 'MEMBER',
+    },
+  ];
 
-  if (!ownerRole) {
-    throw new Error(
-      'Default OWNER role was not found during seeding. Ensure ROLE_DEFINITIONS remain in sync with database records.',
-    );
-  }
-
-  await prisma.membership.upsert({
-    where: {
-      userId_tenantId: {
-        userId: user.id,
+  const seededMembers = await Promise.all(
+    sampleTeamMembers.map((member) =>
+      upsertUserWithMembership({
+        email: member.email,
+        name: member.name,
+        passwordHash: hashedPassword,
         tenantId: tenant.id,
-      },
-    },
+        roleName: member.roleName,
+      }),
+    ),
+  );
+
+  const now = new Date();
+  const currentPeriodEnd = addDays(now, 30);
+  const currentMonthIssuedAt = startOfMonth(now);
+  const previousMonthIssuedAt = monthsAgo(currentMonthIssuedAt, 1);
+
+  const subscription = await prisma.subscription.upsert({
+    where: { stripeSubscriptionId: `sub_${tenantIdentifier}_dev` },
     update: {
-      roleId: ownerRole.id,
+      tenantId: tenant.id,
+      status: SubscriptionStatus.ACTIVE,
+      currentPeriodEnd,
+      cancelAtPeriodEnd: false,
     },
     create: {
-      userId: user.id,
       tenantId: tenant.id,
-      roleId: ownerRole.id,
+      stripeSubscriptionId: `sub_${tenantIdentifier}_dev`,
+      status: SubscriptionStatus.ACTIVE,
+      currentPeriodEnd,
+      cancelAtPeriodEnd: false,
     },
   });
+
+  const paymentMethod = await prisma.paymentMethod.upsert({
+    where: { stripePaymentMethodId: `pm_${tenantIdentifier}_default` },
+    update: {
+      tenantId: tenant.id,
+      brand: 'visa',
+      last4: '4242',
+      expMonth: 12,
+      expYear: now.getFullYear() + 2,
+      isDefault: true,
+    },
+    create: {
+      tenantId: tenant.id,
+      stripePaymentMethodId: `pm_${tenantIdentifier}_default`,
+      brand: 'visa',
+      last4: '4242',
+      expMonth: 12,
+      expYear: now.getFullYear() + 2,
+      isDefault: true,
+    },
+  });
+
+  const invoices = await Promise.all(
+    [
+      {
+        stripeInvoiceId: `in_${tenantIdentifier}_001`,
+        status: 'paid',
+        amountDue: 7500,
+        amountPaid: 7500,
+        issuedAt: previousMonthIssuedAt,
+        dueAt: addDays(previousMonthIssuedAt, 30),
+        paidAt: addDays(previousMonthIssuedAt, 7),
+      },
+      {
+        stripeInvoiceId: `in_${tenantIdentifier}_002`,
+        status: 'open',
+        amountDue: 7500,
+        amountPaid: 0,
+        issuedAt: currentMonthIssuedAt,
+        dueAt: addDays(currentMonthIssuedAt, 30),
+        paidAt: null,
+      },
+    ].map((invoice) =>
+      prisma.invoice.upsert({
+        where: { stripeInvoiceId: invoice.stripeInvoiceId },
+        update: {
+          tenantId: tenant.id,
+          status: invoice.status,
+          amountDue: invoice.amountDue,
+          amountPaid: invoice.amountPaid,
+          currency: 'usd',
+          issuedAt: invoice.issuedAt,
+          dueAt: invoice.dueAt,
+          paidAt: invoice.paidAt,
+        },
+        create: {
+          tenantId: tenant.id,
+          stripeInvoiceId: invoice.stripeInvoiceId,
+          status: invoice.status,
+          amountDue: invoice.amountDue,
+          amountPaid: invoice.amountPaid,
+          currency: 'usd',
+          issuedAt: invoice.issuedAt,
+          dueAt: invoice.dueAt,
+          paidAt: invoice.paidAt,
+        },
+      }),
+    ),
+  );
 
   console.log('Seed complete');
   console.log(`  Tenant: ${tenant.name} (${tenant.slug})`);
-  console.log(`  Admin user: ${user.email}`);
+  console.log(`  Admin user: ${adminUser.email}`);
+  console.log(
+    `  Team members: ${[adminUser.email, ...seededMembers.map(({ user }) => user.email)].join(', ')}`,
+  );
+  console.log(`  Subscription: ${subscription.stripeSubscriptionId} (${subscription.status})`);
+  console.log(`  Default payment method: ${paymentMethod.stripePaymentMethodId}`);
+  console.log(`  Invoices: ${invoices.map((invoice) => invoice.stripeInvoiceId).join(', ')}`);
 }
 
 seed()

--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -74,6 +74,23 @@ async function ensureDefaultRoles() {
   );
 }
 
+function parseRoleName(value: string | undefined, fallback: RoleName): RoleName {
+  if (!value) {
+    return fallback;
+  }
+
+  const normalized = value.trim().toUpperCase();
+  if (normalized === 'OWNER' || normalized === 'ADMIN' || normalized === 'MEMBER') {
+    return normalized as RoleName;
+  }
+
+  console.warn(
+    `Unknown role name "${value}" supplied while seeding. Falling back to ${fallback}.`,
+  );
+
+  return fallback;
+}
+
 async function upsertUserWithMembership({
   email,
   name,
@@ -136,6 +153,7 @@ async function seed() {
   const adminName = process.env.SEED_ADMIN_NAME ?? 'Acme Admin';
   const adminEmail = process.env.SEED_ADMIN_EMAIL ?? 'admin@acme.inc';
   const adminPassword = process.env.SEED_ADMIN_PASSWORD ?? 'ChangeMe123!';
+  const adminRoleName = parseRoleName(process.env.SEED_ADMIN_ROLE, 'OWNER');
 
   await ensureDefaultRoles();
 
@@ -161,7 +179,7 @@ async function seed() {
     name: adminName,
     passwordHash: hashedPassword,
     tenantId: tenant.id,
-    roleName: 'OWNER',
+    roleName: adminRoleName,
   });
 
   const sampleTeamMembers: Array<{ name: string; email: string; roleName: RoleName }> = [

--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -1,4 +1,5 @@
-import { PrismaClient, SubscriptionStatus } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
+import type { SubscriptionStatus } from '@prisma/client';
 import type { Permission, RoleName } from '@saas-boilerplate/shared';
 import * as bcrypt from 'bcryptjs';
 
@@ -193,18 +194,20 @@ async function seed() {
   const currentMonthIssuedAt = startOfMonth(now);
   const previousMonthIssuedAt = monthsAgo(currentMonthIssuedAt, 1);
 
+  const activeStatus: SubscriptionStatus = 'ACTIVE';
+
   const subscription = await prisma.subscription.upsert({
     where: { stripeSubscriptionId: `sub_${tenantIdentifier}_dev` },
     update: {
       tenantId: tenant.id,
-      status: SubscriptionStatus.ACTIVE,
+      status: activeStatus,
       currentPeriodEnd,
       cancelAtPeriodEnd: false,
     },
     create: {
       tenantId: tenant.id,
       stripeSubscriptionId: `sub_${tenantIdentifier}_dev`,
-      status: SubscriptionStatus.ACTIVE,
+      status: activeStatus,
       currentPeriodEnd,
       cancelAtPeriodEnd: false,
     },

--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -96,7 +96,13 @@ async function seed() {
     },
   });
 
-  const ownerRole = await prisma.role.findUniqueOrThrow({ where: { name: 'OWNER' } });
+  const ownerRole = await prisma.role.findUnique({ where: { name: 'OWNER' } });
+
+  if (!ownerRole) {
+    throw new Error(
+      'Default OWNER role was not found during seeding. Ensure ROLE_DEFINITIONS remain in sync with database records.',
+    );
+  }
 
   await prisma.membership.upsert({
     where: {

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
 
-import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import type {
@@ -155,6 +155,8 @@ interface AuthTokens {
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   private readonly membershipInclude = {
     tenant: {
       select: {
@@ -556,6 +558,13 @@ export class AuthService {
     }
 
     const memberships = await this.loadMemberships(user.id);
+
+    if (memberships.length === 0) {
+      this.logger.warn(
+        `User ${user.email} (${user.id}) has no tenant memberships. ` +
+          'If this account should have seeded data, ensure the seed ran against the same database the API is using.',
+      );
+    }
 
     return {
       ...user,

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -100,12 +100,26 @@ const ROLE_DESCRIPTIONS: Record<RoleName, string> = {
   MEMBER: 'Standard member with read-only access.',
 };
 
-type MembershipWithRelations = {
+type MembershipRecord = {
   id: string;
   userId: string;
   tenantId: string;
   roleId: string;
   createdAt: Date;
+  tenant?: {
+    id: string;
+    name: string;
+    slug: string;
+    domain: string | null;
+  } | null;
+  role?: {
+    id: string;
+    name: RoleName;
+    permissions: unknown;
+  } | null;
+};
+
+type HydratedMembership = Omit<MembershipRecord, 'tenant' | 'role'> & {
   tenant: {
     id: string;
     name: string;
@@ -127,7 +141,11 @@ type DbUser = {
   isEmailVerified: boolean;
   createdAt: Date;
   updatedAt: Date;
-  memberships: MembershipWithRelations[];
+  memberships: MembershipRecord[];
+};
+
+type HydratedDbUser = Omit<DbUser, 'memberships'> & {
+  memberships: HydratedMembership[];
 };
 
 interface AuthTokens {
@@ -442,7 +460,7 @@ export class AuthService {
     return domain ? domain.toLowerCase() : null;
   }
 
-  private getActiveMembership(user: DbUser): MembershipWithRelations | null {
+  private getActiveMembership(user: HydratedDbUser): HydratedMembership | null {
     if (user.memberships.length === 0) {
       return null;
     }
@@ -470,51 +488,71 @@ export class AuthService {
   }
 
   private toDbUser(user: unknown): DbUser {
-    return user as DbUser;
+    const record = user as DbUser & { memberships?: MembershipRecord[] | null };
+
+    return {
+      ...record,
+      memberships: Array.isArray(record.memberships) ? record.memberships : [],
+    };
   }
 
-  private async loadMemberships(userId: string): Promise<MembershipWithRelations[]> {
+  private normalizeMembership(membership: MembershipRecord): HydratedMembership {
+    const tenant = membership.tenant;
+    if (!tenant) {
+      throw new Error('Membership is missing tenant relation data');
+    }
+
+    const role = membership.role;
+    if (!role) {
+      throw new Error('Membership is missing role relation data');
+    }
+
+    const permissions = Array.isArray(role.permissions) ? (role.permissions as Permission[]) : [];
+
+    return {
+      id: membership.id,
+      userId: membership.userId,
+      tenantId: membership.tenantId,
+      roleId: membership.roleId,
+      createdAt: membership.createdAt,
+      tenant: {
+        id: tenant.id,
+        name: tenant.name,
+        slug: tenant.slug,
+        domain: tenant.domain,
+      },
+      role: {
+        id: role.id,
+        name: role.name,
+        permissions,
+      },
+    };
+  }
+
+  private async loadMemberships(userId: string): Promise<HydratedMembership[]> {
     const memberships = await this.prisma.membership.findMany({
       where: { userId },
       include: this.membershipInclude,
       orderBy: { createdAt: 'asc' },
     });
 
-    return memberships.map((membership) => {
-      const tenant = membership.tenant;
-      if (!tenant) {
-        throw new Error('Membership is missing tenant relation data');
-      }
-
-      const role = membership.role;
-      if (!role) {
-        throw new Error('Membership is missing role relation data');
-      }
-
-      return {
-        id: membership.id,
-        userId: membership.userId,
-        tenantId: membership.tenantId,
-        roleId: membership.roleId,
-        createdAt: membership.createdAt,
-        tenant: {
-          id: tenant.id,
-          name: tenant.name,
-          slug: tenant.slug,
-          domain: tenant.domain,
-        },
-        role: {
-          id: role.id,
-          name: role.name,
-          permissions: role.permissions as Permission[],
-        },
-      };
-    });
+    return memberships.map((membership) => this.normalizeMembership(membership));
   }
 
-  private async ensureMembershipsLoaded(user: DbUser): Promise<DbUser> {
-    if (user.memberships.length > 0) {
-      return user;
+  private hasHydratedMemberships(user: DbUser): user is HydratedDbUser {
+    return (
+      Array.isArray(user.memberships) &&
+      user.memberships.length > 0 &&
+      user.memberships.every((membership) => membership.tenant && membership.role)
+    );
+  }
+
+  private async ensureMembershipsLoaded(user: DbUser): Promise<HydratedDbUser> {
+    if (this.hasHydratedMemberships(user)) {
+      return {
+        ...user,
+        memberships: user.memberships.map((membership) => this.normalizeMembership(membership)),
+      };
     }
 
     const memberships = await this.loadMemberships(user.id);
@@ -525,34 +563,22 @@ export class AuthService {
     };
   }
 
-  private sanitizeUser(user: DbUser): SharedUser {
+  private sanitizeUser(user: HydratedDbUser): SharedUser {
     const sortedMemberships = [...user.memberships].sort(
       (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
     );
 
-    const membershipSummaries = sortedMemberships.map((membership) => {
-      const tenant = membership.tenant;
-      if (!tenant) {
-        throw new Error('Membership is missing tenant relation data');
-      }
-
-      const role = membership.role;
-      if (!role) {
-        throw new Error('Membership is missing role relation data');
-      }
-
-      return {
-        id: membership.id,
-        tenantId: membership.tenantId,
-        tenantName: tenant.name,
-        tenantSlug: tenant.slug,
-        tenantDomain: tenant.domain,
-        roleId: membership.roleId,
-        roleName: role.name,
-        permissions: role.permissions,
-        createdAt: membership.createdAt.toISOString(),
-      };
-    });
+    const membershipSummaries = sortedMemberships.map((membership) => ({
+      id: membership.id,
+      tenantId: membership.tenantId,
+      tenantName: membership.tenant.name,
+      tenantSlug: membership.tenant.slug,
+      tenantDomain: membership.tenant.domain,
+      roleId: membership.roleId,
+      roleName: membership.role.name,
+      permissions: membership.role.permissions,
+      createdAt: membership.createdAt.toISOString(),
+    }));
 
     const [activeMembershipSummary] = membershipSummaries;
 
@@ -569,7 +595,7 @@ export class AuthService {
     };
   }
 
-  private async generateTokens(user: DbUser): Promise<AuthTokens> {
+  private async generateTokens(user: HydratedDbUser): Promise<AuthTokens> {
     const activeMembership = this.getActiveMembership(user);
     const payload: TokenPayload = {
       sub: user.id,

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -480,24 +480,36 @@ export class AuthService {
       orderBy: { createdAt: 'asc' },
     });
 
-    return memberships.map((membership) => ({
-      id: membership.id,
-      userId: membership.userId,
-      tenantId: membership.tenantId,
-      roleId: membership.roleId,
-      createdAt: membership.createdAt,
-      tenant: {
-        id: membership.tenant.id,
-        name: membership.tenant.name,
-        slug: membership.tenant.slug,
-        domain: membership.tenant.domain,
-      },
-      role: {
-        id: membership.role.id,
-        name: membership.role.name,
-        permissions: membership.role.permissions as Permission[],
-      },
-    }));
+    return memberships.map((membership) => {
+      const tenant = membership.tenant;
+      if (!tenant) {
+        throw new Error('Membership is missing tenant relation data');
+      }
+
+      const role = membership.role;
+      if (!role) {
+        throw new Error('Membership is missing role relation data');
+      }
+
+      return {
+        id: membership.id,
+        userId: membership.userId,
+        tenantId: membership.tenantId,
+        roleId: membership.roleId,
+        createdAt: membership.createdAt,
+        tenant: {
+          id: tenant.id,
+          name: tenant.name,
+          slug: tenant.slug,
+          domain: tenant.domain,
+        },
+        role: {
+          id: role.id,
+          name: role.name,
+          permissions: role.permissions as Permission[],
+        },
+      };
+    });
   }
 
   private async ensureMembershipsLoaded(user: DbUser): Promise<DbUser> {
@@ -518,17 +530,29 @@ export class AuthService {
       (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
     );
 
-    const membershipSummaries = sortedMemberships.map((membership) => ({
-      id: membership.id,
-      tenantId: membership.tenantId,
-      tenantName: membership.tenant.name,
-      tenantSlug: membership.tenant.slug,
-      tenantDomain: membership.tenant.domain,
-      roleId: membership.roleId,
-      roleName: membership.role.name,
-      permissions: membership.role.permissions,
-      createdAt: membership.createdAt.toISOString(),
-    }));
+    const membershipSummaries = sortedMemberships.map((membership) => {
+      const tenant = membership.tenant;
+      if (!tenant) {
+        throw new Error('Membership is missing tenant relation data');
+      }
+
+      const role = membership.role;
+      if (!role) {
+        throw new Error('Membership is missing role relation data');
+      }
+
+      return {
+        id: membership.id,
+        tenantId: membership.tenantId,
+        tenantName: tenant.name,
+        tenantSlug: tenant.slug,
+        tenantDomain: tenant.domain,
+        roleId: membership.roleId,
+        roleName: role.name,
+        permissions: role.permissions,
+        createdAt: membership.createdAt.toISOString(),
+      };
+    });
 
     const [activeMembershipSummary] = membershipSummaries;
 

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -456,19 +456,18 @@ export class AuthService {
   }
 
   private sanitizeUser(user: DbUser): SharedUser {
-    const { password, memberships, ...rest } = user;
-    const sortedMemberships = [...memberships].sort(
+    const sortedMemberships = [...user.memberships].sort(
       (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
     );
     const activeMembership = sortedMemberships[0] ?? null;
 
     return {
-      id: rest.id,
-      email: rest.email,
-      name: rest.name,
-      isEmailVerified: rest.isEmailVerified,
-      createdAt: rest.createdAt.toISOString(),
-      updatedAt: rest.updatedAt.toISOString(),
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      isEmailVerified: user.isEmailVerified,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
       memberships: sortedMemberships.map((membership) => ({
         id: membership.id,
         tenantId: membership.tenantId,

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -459,7 +459,20 @@ export class AuthService {
     const sortedMemberships = [...user.memberships].sort(
       (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
     );
-    const activeMembership = sortedMemberships[0] ?? null;
+
+    const membershipSummaries = sortedMemberships.map((membership) => ({
+      id: membership.id,
+      tenantId: membership.tenantId,
+      tenantName: membership.tenant.name,
+      tenantSlug: membership.tenant.slug,
+      tenantDomain: membership.tenant.domain,
+      roleId: membership.roleId,
+      roleName: membership.role.name,
+      permissions: membership.role.permissions,
+      createdAt: membership.createdAt.toISOString(),
+    }));
+
+    const [activeMembershipSummary] = membershipSummaries;
 
     return {
       id: user.id,
@@ -468,18 +481,9 @@ export class AuthService {
       isEmailVerified: user.isEmailVerified,
       createdAt: user.createdAt.toISOString(),
       updatedAt: user.updatedAt.toISOString(),
-      memberships: sortedMemberships.map((membership) => ({
-        id: membership.id,
-        tenantId: membership.tenantId,
-        tenantName: membership.tenant.name,
-        tenantSlug: membership.tenant.slug,
-        tenantDomain: membership.tenant.domain,
-        roleId: membership.roleId,
-        roleName: membership.role.name,
-        permissions: membership.role.permissions,
-        createdAt: membership.createdAt.toISOString(),
-      })),
-      activeMembershipId: activeMembership?.id,
+      memberships: membershipSummaries,
+      ...(activeMembershipSummary ? { activeMembership: activeMembershipSummary } : {}),
+      activeMembershipId: activeMembershipSummary?.id,
     };
   }
 

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -6,7 +6,9 @@ import { JwtService } from '@nestjs/jwt';
 import type {
   AuthResponse,
   GenericMessageResponse,
+  Permission,
   RequestPasswordResetResponse,
+  RoleName,
   TokenPayload,
   User as SharedUser,
   VerifyTokenResponse,
@@ -86,10 +88,46 @@ const DEFAULT_REFRESH_TOKEN_EXPIRATION_MS = (() => {
   return parsed;
 })();
 
-type DbUser = Omit<SharedUser, 'createdAt' | 'updatedAt'> & {
+const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, Permission[]> = {
+  OWNER: ['MANAGE_USERS', 'MANAGE_BILLING', 'VIEW_BILLING', 'MANAGE_SUBSCRIPTION'],
+  ADMIN: ['MANAGE_USERS', 'MANAGE_BILLING', 'VIEW_BILLING', 'MANAGE_SUBSCRIPTION'],
+  MEMBER: ['VIEW_BILLING'],
+};
+
+const ROLE_DESCRIPTIONS: Record<RoleName, string> = {
+  OWNER: 'Tenant owner with unrestricted access.',
+  ADMIN: 'Administrator with management capabilities.',
+  MEMBER: 'Standard member with read-only access.',
+};
+
+type MembershipWithRelations = {
+  id: string;
+  userId: string;
+  tenantId: string;
+  roleId: string;
+  createdAt: Date;
+  tenant: {
+    id: string;
+    name: string;
+    slug: string;
+    domain: string | null;
+  };
+  role: {
+    id: string;
+    name: RoleName;
+    permissions: Permission[];
+  };
+};
+
+type DbUser = {
+  id: string;
+  email: string;
+  name: string | null;
   password: string;
+  isEmailVerified: boolean;
   createdAt: Date;
   updatedAt: Date;
+  memberships: MembershipWithRelations[];
 };
 
 interface AuthTokens {
@@ -99,6 +137,15 @@ interface AuthTokens {
 
 @Injectable()
 export class AuthService {
+  private readonly userWithMembershipInclude = {
+    memberships: {
+      include: {
+        tenant: true,
+        role: true,
+      },
+    },
+  } as const;
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwtService: JwtService,
@@ -111,17 +158,26 @@ export class AuthService {
       throw new BadRequestException('Email is already registered.');
     }
 
-    const tenant = await this.ensureTenant(dto.tenantName);
+    const tenant = await this.ensureTenant(dto.tenantName, dto.email);
+    const ownerRole = await this.ensureRole('OWNER');
     const hashedPassword = await bcrypt.hash(dto.password, 10);
 
-    const user = await this.prisma.user.create({
-      data: {
-        email: dto.email,
-        password: hashedPassword,
-        name: dto.name,
-        tenantId: tenant.id,
-      },
-    });
+    const user = this.toDbUser(
+      await this.prisma.user.create({
+        data: {
+          email: dto.email,
+          password: hashedPassword,
+          name: dto.name,
+          memberships: {
+            create: {
+              tenant: { connect: { id: tenant.id } },
+              role: { connect: { id: ownerRole.id } },
+            },
+          },
+        },
+        include: this.userWithMembershipInclude,
+      }),
+    );
 
     const tokens = await this.generateTokens(user);
     await this.persistRefreshToken(user.id, tokens.refreshToken);
@@ -133,19 +189,25 @@ export class AuthService {
   }
 
   async login(dto: LoginDto): Promise<AuthResponse> {
-    const user = await this.prisma.user.findUnique({ where: { email: dto.email } });
+    const userRecord = await this.prisma.user.findUnique({
+      where: { email: dto.email },
+      include: this.userWithMembershipInclude,
+    });
 
-    if (!user) {
+    if (!userRecord) {
       throw new UnauthorizedException('Invalid credentials.');
     }
+
+    const user = this.toDbUser(userRecord);
 
     const passwordMatches = await bcrypt.compare(dto.password, user.password);
     if (!passwordMatches) {
       throw new UnauthorizedException('Invalid credentials.');
     }
 
-    await this.prisma.refreshToken.deleteMany({
-      where: { userId: user.id, expiresAt: { lt: new Date() } },
+    await this.prisma.refreshToken.updateMany({
+      where: { userId: user.id, expiresAt: { lt: new Date() }, revoked: false },
+      data: { revoked: true },
     });
 
     const tokens = await this.generateTokens(user);
@@ -158,20 +220,28 @@ export class AuthService {
   }
 
   async refresh(dto: RefreshTokenDto): Promise<AuthResponse> {
-    const user = await this.prisma.user.findUnique({ where: { id: dto.userId } });
-    if (!user) {
+    const userRecord = await this.prisma.user.findUnique({
+      where: { id: dto.userId },
+      include: this.userWithMembershipInclude,
+    });
+    if (!userRecord) {
       throw new UnauthorizedException('Invalid refresh request.');
     }
 
+    const user = this.toDbUser(userRecord);
+
     const refreshTokens = await this.prisma.refreshToken.findMany({
-      where: { userId: user.id },
+      where: { userId: user.id, revoked: false },
       orderBy: { createdAt: 'desc' },
     });
 
     let validTokenId: string | null = null;
     for (const token of refreshTokens) {
       if (token.expiresAt < new Date()) {
-        await this.prisma.refreshToken.delete({ where: { id: token.id } });
+        await this.prisma.refreshToken.update({
+          where: { id: token.id },
+          data: { revoked: true },
+        });
         continue;
       }
 
@@ -186,7 +256,10 @@ export class AuthService {
       throw new UnauthorizedException('Invalid refresh token.');
     }
 
-    await this.prisma.refreshToken.delete({ where: { id: validTokenId } });
+    await this.prisma.refreshToken.update({
+      where: { id: validTokenId },
+      data: { revoked: true },
+    });
 
     const tokens = await this.generateTokens(user);
     await this.persistRefreshToken(user.id, tokens.refreshToken);
@@ -202,10 +275,15 @@ export class AuthService {
       const payload = await this.jwtService.verifyAsync<TokenPayload>(dto.token, {
         secret: this.configService.get<string>('JWT_ACCESS_TOKEN_SECRET', 'access-secret'),
       });
-      const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
-      if (!user) {
+      const userRecord = await this.prisma.user.findUnique({
+        where: { id: payload.sub },
+        include: this.userWithMembershipInclude,
+      });
+      if (!userRecord) {
         throw new UnauthorizedException('Invalid token.');
       }
+
+      const user = this.toDbUser(userRecord);
 
       return {
         valid: true,
@@ -302,7 +380,7 @@ export class AuthService {
     };
   }
 
-  private async ensureTenant(name: string) {
+  private async ensureTenant(name: string, requesterEmail: string) {
     const baseSlug = this.slugify(name) || `tenant-${randomBytes(3).toString('hex')}`;
     let slug = baseSlug;
     let counter = 1;
@@ -317,10 +395,18 @@ export class AuthService {
       slug = `${baseSlug}-${counter++}`;
     }
 
+    const requestedDomain = this.extractDomain(requesterEmail);
+    const domain = requestedDomain
+      ? (await this.prisma.tenant.findUnique({ where: { domain: requestedDomain } }))
+        ? null
+        : requestedDomain
+      : null;
+
     return this.prisma.tenant.create({
       data: {
         name,
         slug,
+        domain,
       },
     });
   }
@@ -333,24 +419,83 @@ export class AuthService {
       .replace(/(^-|-$)+/g, '');
   }
 
+  private extractDomain(email: string) {
+    const [, domain] = email.split('@');
+    return domain ? domain.toLowerCase() : null;
+  }
+
+  private getActiveMembership(user: DbUser): MembershipWithRelations | null {
+    if (user.memberships.length === 0) {
+      return null;
+    }
+
+    return [...user.memberships].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[0];
+  }
+
+  private async ensureRole(name: RoleName) {
+    const permissions = DEFAULT_ROLE_PERMISSIONS[name] ?? [];
+    const description = ROLE_DESCRIPTIONS[name] ?? `${name} role`;
+
+    return this.prisma.role.upsert({
+      where: { name },
+      update: {
+        description,
+        permissions,
+      },
+      create: {
+        id: `role-${name.toLowerCase()}`,
+        name,
+        description,
+        permissions,
+      },
+    });
+  }
+
+  private toDbUser(user: unknown): DbUser {
+    return user as DbUser;
+  }
+
   private sanitizeUser(user: DbUser): SharedUser {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { password, ...sanitized } = user;
+    const { password, memberships, ...rest } = user;
+    const sortedMemberships = [...memberships].sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    );
+    const activeMembership = sortedMemberships[0] ?? null;
 
     return {
-      ...sanitized,
-      createdAt: sanitized.createdAt.toISOString(),
-      updatedAt: sanitized.updatedAt.toISOString(),
+      id: rest.id,
+      email: rest.email,
+      name: rest.name,
+      isEmailVerified: rest.isEmailVerified,
+      createdAt: rest.createdAt.toISOString(),
+      updatedAt: rest.updatedAt.toISOString(),
+      memberships: sortedMemberships.map((membership) => ({
+        id: membership.id,
+        tenantId: membership.tenantId,
+        tenantName: membership.tenant.name,
+        tenantSlug: membership.tenant.slug,
+        tenantDomain: membership.tenant.domain,
+        roleId: membership.roleId,
+        roleName: membership.role.name,
+        permissions: membership.role.permissions,
+        createdAt: membership.createdAt.toISOString(),
+      })),
+      activeMembershipId: activeMembership?.id,
     };
   }
 
   private async generateTokens(user: DbUser): Promise<AuthTokens> {
+    const activeMembership = this.getActiveMembership(user);
     const payload: TokenPayload = {
       sub: user.id,
-      tenantId: user.tenantId,
       email: user.email,
-      role: user.role,
     };
+
+    if (activeMembership) {
+      payload.membershipId = activeMembership.id;
+      payload.tenantId = activeMembership.tenantId;
+      payload.role = activeMembership.role.name;
+    }
 
     const accessToken = await this.jwtService.signAsync(payload, {
       secret: this.configService.get<string>('JWT_ACCESS_TOKEN_SECRET', 'access-secret'),
@@ -383,6 +528,7 @@ export class AuthService {
         userId,
         tokenHash: hashedToken,
         expiresAt,
+        revoked: false,
       },
     });
   }

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -137,11 +137,29 @@ interface AuthTokens {
 
 @Injectable()
 export class AuthService {
+  private readonly membershipInclude = {
+    tenant: {
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        domain: true,
+      },
+    },
+    role: {
+      select: {
+        id: true,
+        name: true,
+        permissions: true,
+      },
+    },
+  } as const;
+
   private readonly userWithMembershipInclude = {
     memberships: {
-      include: {
-        tenant: true,
-        role: true,
+      include: this.membershipInclude,
+      orderBy: {
+        createdAt: 'asc',
       },
     },
   } as const;
@@ -162,22 +180,22 @@ export class AuthService {
     const ownerRole = await this.ensureRole('OWNER');
     const hashedPassword = await bcrypt.hash(dto.password, 10);
 
-    const user = this.toDbUser(
-      await this.prisma.user.create({
-        data: {
-          email: dto.email,
-          password: hashedPassword,
-          name: dto.name,
-          memberships: {
-            create: {
-              tenant: { connect: { id: tenant.id } },
-              role: { connect: { id: ownerRole.id } },
-            },
+    const createdUser = await this.prisma.user.create({
+      data: {
+        email: dto.email,
+        password: hashedPassword,
+        name: dto.name,
+        memberships: {
+          create: {
+            tenant: { connect: { id: tenant.id } },
+            role: { connect: { id: ownerRole.id } },
           },
         },
-        include: this.userWithMembershipInclude,
-      }),
-    );
+      },
+      include: this.userWithMembershipInclude,
+    });
+
+    const user = await this.ensureMembershipsLoaded(this.toDbUser(createdUser));
 
     const tokens = await this.generateTokens(user);
     await this.persistRefreshToken(user.id, tokens.refreshToken);
@@ -198,7 +216,7 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials.');
     }
 
-    const user = this.toDbUser(userRecord);
+    const user = await this.ensureMembershipsLoaded(this.toDbUser(userRecord));
 
     const passwordMatches = await bcrypt.compare(dto.password, user.password);
     if (!passwordMatches) {
@@ -228,7 +246,7 @@ export class AuthService {
       throw new UnauthorizedException('Invalid refresh request.');
     }
 
-    const user = this.toDbUser(userRecord);
+    const user = await this.ensureMembershipsLoaded(this.toDbUser(userRecord));
 
     const refreshTokens = await this.prisma.refreshToken.findMany({
       where: { userId: user.id, revoked: false },
@@ -283,7 +301,7 @@ export class AuthService {
         throw new UnauthorizedException('Invalid token.');
       }
 
-      const user = this.toDbUser(userRecord);
+      const user = await this.ensureMembershipsLoaded(this.toDbUser(userRecord));
 
       return {
         valid: true,
@@ -453,6 +471,46 @@ export class AuthService {
 
   private toDbUser(user: unknown): DbUser {
     return user as DbUser;
+  }
+
+  private async loadMemberships(userId: string): Promise<MembershipWithRelations[]> {
+    const memberships = await this.prisma.membership.findMany({
+      where: { userId },
+      include: this.membershipInclude,
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return memberships.map((membership) => ({
+      id: membership.id,
+      userId: membership.userId,
+      tenantId: membership.tenantId,
+      roleId: membership.roleId,
+      createdAt: membership.createdAt,
+      tenant: {
+        id: membership.tenant.id,
+        name: membership.tenant.name,
+        slug: membership.tenant.slug,
+        domain: membership.tenant.domain,
+      },
+      role: {
+        id: membership.role.id,
+        name: membership.role.name,
+        permissions: membership.role.permissions as Permission[],
+      },
+    }));
+  }
+
+  private async ensureMembershipsLoaded(user: DbUser): Promise<DbUser> {
+    if (user.memberships.length > 0) {
+      return user;
+    }
+
+    const memberships = await this.loadMemberships(user.id);
+
+    return {
+      ...user,
+      memberships,
+    };
   }
 
   private sanitizeUser(user: DbUser): SharedUser {

--- a/packages/backend/src/types/prisma.d.ts
+++ b/packages/backend/src/types/prisma.d.ts
@@ -165,5 +165,5 @@ declare module '@prisma/client/default' {
 }
 
 declare module '@prisma/client' {
-  export { PrismaClient, PrismaClientOptions } from '@prisma/client/default';
+  export * from '@prisma/client/default';
 }

--- a/packages/backend/src/types/prisma.d.ts
+++ b/packages/backend/src/types/prisma.d.ts
@@ -11,7 +11,11 @@ declare module '@prisma/client/default' {
   type UnknownArgs = Record<string, unknown>;
 
   export type RoleName = 'OWNER' | 'ADMIN' | 'MEMBER';
-  export type Permission = 'MANAGE_USERS' | 'MANAGE_BILLING' | 'VIEW_BILLING' | 'MANAGE_SUBSCRIPTION';
+  export type Permission =
+    | 'MANAGE_USERS'
+    | 'MANAGE_BILLING'
+    | 'VIEW_BILLING'
+    | 'MANAGE_SUBSCRIPTION';
   export type SubscriptionStatus =
     | 'INCOMPLETE'
     | 'INCOMPLETE_EXPIRED'

--- a/packages/backend/src/types/prisma.d.ts
+++ b/packages/backend/src/types/prisma.d.ts
@@ -10,6 +10,18 @@ declare module '@prisma/client/default' {
 
   type UnknownArgs = Record<string, unknown>;
 
+  export type RoleName = 'OWNER' | 'ADMIN' | 'MEMBER';
+  export type Permission = 'MANAGE_USERS' | 'MANAGE_BILLING' | 'VIEW_BILLING' | 'MANAGE_SUBSCRIPTION';
+  export type SubscriptionStatus =
+    | 'INCOMPLETE'
+    | 'INCOMPLETE_EXPIRED'
+    | 'TRIALING'
+    | 'ACTIVE'
+    | 'PAST_DUE'
+    | 'CANCELED'
+    | 'UNPAID'
+    | 'PAUSED';
+
   interface ModelDelegate<T> {
     findUnique(args: UnknownArgs): Promise<T | null>;
     findMany(args?: UnknownArgs): Promise<T[]>;
@@ -26,10 +38,46 @@ declare module '@prisma/client/default' {
     email: string;
     password: string;
     name: string | null;
-    tenantId: string;
-    role: string;
+    isEmailVerified: boolean;
     createdAt: Date;
     updatedAt: Date;
+    memberships?: Membership[];
+    refreshTokens?: RefreshToken[];
+    passwordResetTokens?: PasswordResetToken[];
+  }
+
+  export interface Tenant {
+    id: string;
+    name: string;
+    slug: string;
+    domain: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    memberships?: Membership[];
+    subscriptions?: Subscription[];
+    paymentMethods?: PaymentMethod[];
+    invoices?: Invoice[];
+  }
+
+  export interface Membership {
+    id: string;
+    userId: string;
+    tenantId: string;
+    roleId: string;
+    createdAt: Date;
+    user?: User;
+    tenant?: Tenant;
+    role?: Role;
+  }
+
+  export interface Role {
+    id: string;
+    name: RoleName;
+    description: string | null;
+    permissions: Permission[];
+    createdAt: Date;
+    updatedAt: Date;
+    memberships?: Membership[];
   }
 
   export interface RefreshToken {
@@ -37,7 +85,9 @@ declare module '@prisma/client/default' {
     userId: string;
     tokenHash: string;
     expiresAt: Date;
+    revoked: boolean;
     createdAt: Date;
+    user?: User;
   }
 
   export interface PasswordResetToken {
@@ -47,14 +97,47 @@ declare module '@prisma/client/default' {
     expiresAt: Date;
     consumed: boolean;
     createdAt: Date;
+    user?: User;
   }
 
-  export interface Tenant {
+  export interface Subscription {
     id: string;
-    name: string;
-    slug: string;
+    tenantId: string;
+    stripeSubscriptionId: string;
+    status: SubscriptionStatus;
+    currentPeriodEnd: Date;
+    cancelAtPeriodEnd: boolean;
     createdAt: Date;
     updatedAt: Date;
+    tenant?: Tenant;
+  }
+
+  export interface PaymentMethod {
+    id: string;
+    tenantId: string;
+    stripePaymentMethodId: string;
+    brand: string | null;
+    last4: string | null;
+    expMonth: number | null;
+    expYear: number | null;
+    isDefault: boolean;
+    createdAt: Date;
+    tenant?: Tenant;
+  }
+
+  export interface Invoice {
+    id: string;
+    tenantId: string;
+    stripeInvoiceId: string;
+    status: string;
+    amountDue: number;
+    amountPaid: number;
+    currency: string;
+    issuedAt: Date;
+    dueAt: Date | null;
+    paidAt: Date | null;
+    createdAt: Date;
+    tenant?: Tenant;
   }
 
   export class PrismaClient {
@@ -66,9 +149,14 @@ declare module '@prisma/client/default' {
     $transaction<T>(fn: (client: PrismaClient) => Promise<T>): Promise<T>;
 
     user: ModelDelegate<User>;
+    tenant: ModelDelegate<Tenant>;
+    membership: ModelDelegate<Membership>;
+    role: ModelDelegate<Role>;
     refreshToken: ModelDelegate<RefreshToken>;
     passwordResetToken: ModelDelegate<PasswordResetToken>;
-    tenant: ModelDelegate<Tenant>;
+    subscription: ModelDelegate<Subscription>;
+    paymentMethod: ModelDelegate<PaymentMethod>;
+    invoice: ModelDelegate<Invoice>;
   }
 }
 

--- a/packages/frontend/src/lib/auth.ts
+++ b/packages/frontend/src/lib/auth.ts
@@ -10,6 +10,9 @@ export const authStorage = {
     localStorage.setItem(REFRESH_TOKEN_KEY, auth.refreshToken);
     localStorage.setItem(USER_KEY, JSON.stringify(auth.user));
   },
+  setUser(user: AuthResponse['user']) {
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
+  },
   clear() {
     localStorage.removeItem(ACCESS_TOKEN_KEY);
     localStorage.removeItem(REFRESH_TOKEN_KEY);

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -1,17 +1,26 @@
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import type { VerifyTokenResponse } from '@saas-boilerplate/shared';
+import type { Permission, VerifyTokenResponse } from '@saas-boilerplate/shared';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import apiClient from '../lib/api';
 import { authStorage, isAuthenticated } from '../lib/auth';
 import '../styles/dashboard.css';
 
+const formatPermission = (permission: Permission) =>
+  permission
+    .toLowerCase()
+    .split('_')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
 export const DashboardPage = () => {
   const navigate = useNavigate();
-  const user = authStorage.getUser();
+  const authenticated = isAuthenticated();
+  const [user, setUser] = useState(() => authStorage.getUser());
 
   const verifyQuery = useQuery({
-    queryKey: ['verify', user?.id],
+    queryKey: ['verify'],
     queryFn: async () => {
       const token = authStorage.getAccessToken();
       if (!token) {
@@ -20,21 +29,54 @@ export const DashboardPage = () => {
       const { data } = await apiClient.post<VerifyTokenResponse>('/auth/verify', { token });
       return data;
     },
-    enabled: isAuthenticated(),
+    enabled: authenticated,
+    staleTime: 60_000,
   });
 
-  const activeMembership =
-    user?.memberships?.find((membership) => membership.id === user.activeMembershipId) ??
-    user?.memberships?.[0];
-  const tenantLabel = activeMembership?.tenantName ?? 'Unknown tenant';
-  const roleLabel = activeMembership?.roleName ?? 'Unknown role';
+  useEffect(() => {
+    if (verifyQuery.data?.user) {
+      setUser(verifyQuery.data.user);
+      authStorage.setUser(verifyQuery.data.user);
+    }
+  }, [verifyQuery.data]);
 
-  if (!isAuthenticated()) {
+  const activeMembership = useMemo(() => {
+    if (!user) {
+      return undefined;
+    }
+
+    if (user.activeMembership) {
+      return user.activeMembership;
+    }
+
+    if (user.activeMembershipId) {
+      const match = user.memberships.find(
+        (membership) => membership.id === user.activeMembershipId,
+      );
+      if (match) {
+        return match;
+      }
+    }
+
+    return user.memberships[0];
+  }, [user]);
+
+  const activeMembershipId = activeMembership?.id ?? user?.activeMembershipId;
+  if (!authenticated) {
     return <Navigate to="/login" replace />;
   }
 
+  const tenantLabel =
+    activeMembership?.tenantName ??
+    (verifyQuery.isLoading ? 'Loading tenant…' : user ? 'No tenant assigned' : '—');
+  const roleLabel =
+    activeMembership?.roleName ??
+    (verifyQuery.isLoading ? 'Loading role…' : user ? 'No role assigned' : '—');
+  const memberships = user?.memberships ?? [];
+
   const handleSignOut = () => {
     authStorage.clear();
+    setUser(null);
     navigate('/login', { replace: true });
   };
 
@@ -69,6 +111,57 @@ export const DashboardPage = () => {
             <dd>{user?.id}</dd>
           </div>
         </dl>
+      </section>
+      <section className="dashboard__card">
+        <h2>Tenant memberships</h2>
+        {memberships.length === 0 ? (
+          <p className="dashboard__empty">You haven&apos;t joined any tenants yet.</p>
+        ) : (
+          <div className="dashboard__table-wrapper">
+            <table className="dashboard__table">
+              <thead>
+                <tr>
+                  <th scope="col">Tenant</th>
+                  <th scope="col">Role</th>
+                  <th scope="col">Permissions</th>
+                  <th scope="col">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {memberships.map((membership) => {
+                  const isActive = membership.id === activeMembershipId;
+
+                  return (
+                    <tr
+                      key={membership.id}
+                      className={isActive ? 'dashboard__table-row--active' : undefined}
+                    >
+                      <td>
+                        <strong>{membership.tenantName}</strong>
+                        <div className="dashboard__subtle">
+                          {membership.tenantDomain ?? `/${membership.tenantSlug}`}
+                        </div>
+                      </td>
+                      <td>{membership.roleName}</td>
+                      <td>
+                        {membership.permissions.length === 0 ? (
+                          <span className="dashboard__subtle">No special permissions</span>
+                        ) : (
+                          <ul className="dashboard__permissions">
+                            {membership.permissions.map((permission) => (
+                              <li key={permission}>{formatPermission(permission)}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </td>
+                      <td>{new Date(membership.createdAt).toLocaleDateString()}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </section>
       <section className="dashboard__card">
         <h2>Token status</h2>

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -112,7 +112,13 @@ export const DashboardPage = () => {
       <section className="dashboard__card">
         <h2>Tenant memberships</h2>
         {memberships.length === 0 ? (
-          <p className="dashboard__empty">You haven&apos;t joined any tenants yet.</p>
+          <p className="dashboard__empty">
+            <span>You haven&apos;t joined any tenants yet.</span>{' '}
+            <span>
+              If you recently ran the seed script, double-check that the backend is connected to the
+              same database instance so the example memberships appear here.
+            </span>
+          </p>
         ) : (
           <div className="dashboard__table-wrapper">
             <table className="dashboard__table">

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ export const DashboardPage = () => {
   const navigate = useNavigate();
   const authenticated = isAuthenticated();
   const [user, setUser] = useState(() => authStorage.getUser());
+  const memberships = user?.memberships ?? [];
 
   const verifyQuery = useQuery({
     queryKey: ['verify'],
@@ -50,16 +51,14 @@ export const DashboardPage = () => {
     }
 
     if (user.activeMembershipId) {
-      const match = user.memberships.find(
-        (membership) => membership.id === user.activeMembershipId,
-      );
+      const match = memberships.find((membership) => membership.id === user.activeMembershipId);
       if (match) {
         return match;
       }
     }
 
-    return user.memberships[0];
-  }, [user]);
+    return memberships[0];
+  }, [user, memberships]);
 
   const activeMembershipId = activeMembership?.id ?? user?.activeMembershipId;
   if (!authenticated) {
@@ -72,8 +71,6 @@ export const DashboardPage = () => {
   const roleLabel =
     activeMembership?.roleName ??
     (verifyQuery.isLoading ? 'Loading role…' : user ? 'No role assigned' : '—');
-  const memberships = user?.memberships ?? [];
-
   const handleSignOut = () => {
     authStorage.clear();
     setUser(null);

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -23,7 +23,11 @@ export const DashboardPage = () => {
     enabled: isAuthenticated(),
   });
 
-  const tenantLabel = user?.tenantId ?? 'Unknown tenant';
+  const activeMembership =
+    user?.memberships?.find((membership) => membership.id === user.activeMembershipId) ??
+    user?.memberships?.[0];
+  const tenantLabel = activeMembership?.tenantName ?? 'Unknown tenant';
+  const roleLabel = activeMembership?.roleName ?? 'Unknown role';
 
   if (!isAuthenticated()) {
     return <Navigate to="/login" replace />;
@@ -55,6 +59,10 @@ export const DashboardPage = () => {
           <div>
             <dt>Tenant</dt>
             <dd>{tenantLabel}</dd>
+          </div>
+          <div>
+            <dt>Role</dt>
+            <dd>{roleLabel}</dd>
           </div>
           <div>
             <dt>User ID</dt>

--- a/packages/frontend/src/styles/dashboard.css
+++ b/packages/frontend/src/styles/dashboard.css
@@ -68,6 +68,71 @@
   font-weight: 600;
 }
 
+.dashboard__table-wrapper {
+  overflow-x: auto;
+  margin-top: 1.5rem;
+}
+
+.dashboard__table {
+  width: 100%;
+  min-width: 540px;
+  border-collapse: collapse;
+}
+
+.dashboard__table th {
+  text-align: left;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.dashboard__table td {
+  padding: 0.85rem 0;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: top;
+}
+
+.dashboard__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.dashboard__table-row--active td {
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.12), rgba(59, 130, 246, 0));
+}
+
+.dashboard__subtle {
+  margin-top: 0.25rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.dashboard__permissions {
+  margin: 0.25rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  list-style: none;
+}
+
+.dashboard__permissions li {
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.3rem 0.75rem;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.dashboard__empty {
+  margin: 0.75rem 0 0;
+  color: #64748b;
+}
+
 .dashboard__token {
   background: #0f172a;
   color: #f8fafc;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,6 +39,7 @@ export interface User {
   createdAt: string;
   updatedAt: string;
   memberships: MembershipSummary[];
+  activeMembership?: MembershipSummary;
   activeMembershipId?: string;
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,26 +1,53 @@
+export type Permission = 'MANAGE_USERS' | 'MANAGE_BILLING' | 'VIEW_BILLING' | 'MANAGE_SUBSCRIPTION';
+export type RoleName = 'OWNER' | 'ADMIN' | 'MEMBER';
+export type SubscriptionStatus =
+  | 'INCOMPLETE'
+  | 'INCOMPLETE_EXPIRED'
+  | 'TRIALING'
+  | 'ACTIVE'
+  | 'PAST_DUE'
+  | 'CANCELED'
+  | 'UNPAID'
+  | 'PAUSED';
+
 export interface Tenant {
   id: string;
   name: string;
   slug: string;
+  domain?: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface MembershipSummary {
+  id: string;
+  tenantId: string;
+  tenantName: string;
+  tenantSlug: string;
+  tenantDomain?: string | null;
+  roleId: string;
+  roleName: RoleName;
+  permissions: Permission[];
+  createdAt: string;
 }
 
 export interface User {
   id: string;
   email: string;
   name?: string | null;
-  role: string;
-  tenantId: string;
+  isEmailVerified: boolean;
   createdAt: string;
   updatedAt: string;
+  memberships: MembershipSummary[];
+  activeMembershipId?: string;
 }
 
 export interface TokenPayload {
   sub: string;
   email: string;
-  tenantId: string;
-  role: string;
+  membershipId?: string;
+  tenantId?: string;
+  role?: RoleName;
   iat?: number;
   exp?: number;
 }


### PR DESCRIPTION
## Summary
- expand the Prisma schema with permission enums, membership, billing, and payment models plus supporting indexes and comments
- add a migration to create new enums/tables, migrate existing user tenant data into memberships, and seed default roles
- update backend auth flows, shared types, seeding, and the dashboard UI to work with membership-driven tenants and richer token payloads

## Testing
- `pnpm -r lint` *(fails: pnpm download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d17041bf2c832ca473051907f37c3b